### PR TITLE
feat(cli): add support for hiding the FigFont banner

### DIFF
--- a/packages/cli/examples/wc/index.ts
+++ b/packages/cli/examples/wc/index.ts
@@ -131,7 +131,8 @@ const wcApp = CliApp.make({
   name: "Effect-TS Word Count",
   version: "0.1.2",
   summary: Help.text("counts the words in a file"),
-  command: wc
+  command: wc,
+  config: { showBanner: false }
 })
 
 function handleOption(

--- a/packages/cli/src/CliConfig/index.ts
+++ b/packages/cli/src/CliConfig/index.ts
@@ -22,6 +22,10 @@ export interface CliConfig {
    */
   readonly caseSensitive: boolean
   /**
+   * Whether or not to show the banner text in the CLI usage output.
+   */
+  readonly showBanner: boolean
+  /**
    * The Figlet font that will be used to render the banner for the CLI program.
    */
   readonly bannerFont: InternalFont
@@ -35,12 +39,14 @@ export function make(
   params: Partial<{
     readonly autoCorrectLimit: number
     readonly caseSensitive: boolean
+    readonly showBanner: boolean
     readonly bannerFont: InternalFont
   }> = {}
 ): CliConfig {
   const defaultCliConfig = {
     autoCorrectLimit: 2,
     caseSensitive: true,
+    showBanner: true,
     bannerFont: "slant"
   }
   return Object.assign({}, defaultCliConfig, params)


### PR DESCRIPTION
This PR adds optional support for hiding the FigFont banner rendered to the CLI usage. This PR is really a temporizing measure until the loading of fonts in `@effect-ts/figlet` can be improved (at the moment it is relying on `__dirname` which breaks ESM builds.

In addition, I updated the `wc` example to show how one might go about hiding the banner using the `CliConfig`.

![Hidden Banner](https://user-images.githubusercontent.com/38051499/151806009-d728eed2-617a-4ba2-ad04-f5eb5fe92829.png)
