### PR TITLE
fix `withDefault` types

### DIFF
--- a/.changeset/quick-donkeys-talk.md
+++ b/.changeset/quick-donkeys-talk.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+Fixed `withDefault` types

--- a/docs/modules/Options.ts.md
+++ b/docs/modules/Options.ts.md
@@ -196,8 +196,8 @@ Added in v1.0.0
 
 ```ts
 export declare const withDefault: {
-  <A>(value: A): (self: Options<A>) => Options<A>
-  <A>(self: Options<A>, value: A): Options<A>
+  <A, B extends A>(value: B): (self: Options<A>) => Options<A>
+  <A, B extends A>(self: Options<A>, value: B): Options<A>
 }
 ```
 

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -351,8 +351,8 @@ export const validate: {
  * @category combinators
  */
 export const withDefault: {
-  <A>(value: A): (self: Options<A>) => Options<A>
-  <A>(self: Options<A>, value: A): Options<A>
+  <A, B extends A>(value: B): (self: Options<A>) => Options<A>
+  <A, B extends A>(self: Options<A>, value: B): Options<A>
 } = internal.withDefault
 
 /**


### PR DESCRIPTION
This fixes the type parameters of `withDefault` so that it doesn't widen (or narrow) the type when used (e.g. from an enumeration to `string`).