### PR TITLE
fix public module exports

### DIFF
--- a/.changeset/cold-cups-prove.md
+++ b/.changeset/cold-cups-prove.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": minor
+---
+
+Fixed exports of public module at subpaths

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
     "functional-programming"
   ],
   "sideEffects": false,
+  "effect": {
+    "generateExports": {
+      "include": [
+        "**/*.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "pnpm build-prepare && pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "build-prepare": "build-utils prepare-v2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
       "include": [
         "**/*.ts"
       ]
+    },
+    "generateIndex": {
+      "include": [
+        "**/*.ts"
+      ]
     }
   },
   "scripts": {
@@ -65,7 +70,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.23.3",
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
-    "@effect/build-utils": "^0.4.0",
+    "@effect/build-utils": "^0.4.1",
     "@effect/docgen": "^0.3.2",
     "@effect/eslint-plugin": "^0.1.2",
     "@effect/language-service": "^0.0.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ devDependencies:
     specifier: ^2.26.2
     version: 2.26.2
   '@effect/build-utils':
-    specifier: ^0.4.0
-    version: 0.4.0
+    specifier: ^0.4.1
+    version: 0.4.1
   '@effect/docgen':
     specifier: ^0.3.2
     version: 0.3.2(fast-check@3.13.2)(tsx@4.1.0)(typescript@5.2.2)
@@ -663,8 +663,8 @@ packages:
     resolution: {integrity: sha512-rPwwm/RrFIolz6xHa8Kzpshuwpe+xu/XcEw9iUmRF2tnyIwxxaW7XoFKaQ+GfPju81cKpH4vJeq7/2IizKvyjg==}
     dev: true
 
-  /@effect/build-utils@0.4.0:
-    resolution: {integrity: sha512-1dL2qgzfGECCvMZ2BXhNjAdSDsKS9zpNJne8caxXRI8FtjFNPuj3HYOhYZVmaYfSvzwlC+p9nPBTRaiczoLe8w==}
+  /@effect/build-utils@0.4.1:
+    resolution: {integrity: sha512-p4Fm6jAnXEi1HaG6lRQN6uBWfFmMpoXetedMshuKO19EFk9OSAkcTl4Hb2wiE/Ex34xsmxg9gKlFpAZR6gc0ww==}
     engines: {node: '>=16.17.1'}
     hasBin: true
     dev: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ export * as HelpDoc from "./HelpDoc.js"
 /**
  * @since 1.0.0
  */
+export * as Span from "./HelpDoc/Span.js"
+
+/**
+ * @since 1.0.0
+ */
 export * as Options from "./Options.js"
 
 /**
@@ -67,6 +72,11 @@ export * as Primitive from "./Primitive.js"
  * @since 1.0.0
  */
 export * as Prompt from "./Prompt.js"
+
+/**
+ * @since 1.0.0
+ */
+export * as Action from "./Prompt/Action.js"
 
 /**
  * @since 1.0.0


### PR DESCRIPTION
This generates exports for everything that's in `src` except stuff under `internal` (excluded by default). If you later want to also exclude other stuff, you could do that by tweaking either the `include` or `exclude` globs.