### PR TITLE
Support multi-valued arguments appearing anywhere in arguments

### DIFF
--- a/.changeset/kind-sloths-think.md
+++ b/.changeset/kind-sloths-think.md
@@ -1,0 +1,5 @@
+---
+"@effect/cli": patch
+---
+
+support multi-valued arguments appearing anywhere in command-line arguments

--- a/examples/testing.ts
+++ b/examples/testing.ts
@@ -1,0 +1,32 @@
+import * as CliApp from "@effect/cli/CliApp"
+import * as Command from "@effect/cli/Command"
+import * as Options from "@effect/cli/Options"
+import * as NodeContext from "@effect/platform-node/NodeContext"
+import * as Runtime from "@effect/platform-node/Runtime"
+import * as Console from "effect/Console"
+import * as Effect from "effect/Effect"
+
+const command = Command.standard("foo", {
+  options: Options.keyValueMap("flag")
+})
+
+const app = CliApp.make({
+  name: "Test",
+  version: "1.0.0",
+  command
+})
+
+const program = Effect.sync(() => process.argv.slice(2)).pipe(
+  Effect.flatMap((args) =>
+    CliApp.run(
+      app,
+      args,
+      (parsed) => Console.dir(Array.from(parsed.options), { depth: null, colors: true })
+    )
+  )
+)
+
+program.pipe(
+  Effect.provide(NodeContext.layer),
+  Runtime.runMain
+)


### PR DESCRIPTION
Adds support for properly parsing multi-valued `Options` that can appear in many places:
- `my-command --foo bar my-arg --foo baz` will properly parse both instances of `--foo`
- `my-command --foo key1=val1 my-arg --foo key2=val2` will properly parse both instances of `--foo`